### PR TITLE
Listen model events

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm install backbone-computed-properties
 
 ### Why Computed Properties?
 
-Computed properties let you declare functions as properties. It's super handy for taking one or more normal properties and transforming or manipulating their data to create a new value. 
+Computed properties let you declare functions as properties. It's super handy for taking one or more normal properties and transforming or manipulating their data to create a new value.
 
 You can achieve computed properties now in Backbone with observers in your model's _initialize()_ method.
 
@@ -39,7 +39,7 @@ Backbone.Model.extend({
 
 		// could have more here ...
 	},
-		
+
 	computeHasDiscount: function() { /* implementation */ }
 });
 ```
@@ -65,6 +65,16 @@ david.set({ last: 'Doe' });
 david.get('fullName'); // David Doe
 david.set({ first: 'David', last: 'Tang' });
 david.get('fullName'); // David Tang
+```
+
+You can also set up computed properties that relies on model events using the prefix **event:**, example:
+
+```js
+Person = Backbone.Model.extend({
+  syncCount: Backbone.Computed('event:sync', function() {
+    return this.get('syncCount') + 1;
+  })
+});
 ```
 
 ### Chaining Computed Properties

--- a/tests/backbone-computed.spec.js
+++ b/tests/backbone-computed.spec.js
@@ -63,4 +63,21 @@ describe('Backbone.Computed', function() {
 
     expect(spy.callCount).to.equal(0);
   });
+
+  it('should allow computed properties to depend on a model event', function() {
+    Person = Backbone.Model.extend({
+      syncCount: Backbone.Computed('event:sync', function() {
+       if (_.isUndefined(this.get('syncCount'))) {
+         return 0;
+       } else {
+         return this.get('syncCount') + 1;
+       };
+      })
+    });
+
+    david = new Person();
+    expect(david.get('syncCount')).to.equal(0);
+    david.trigger('sync');
+    expect(david.get('syncCount')).to.equal(1);
+  });
 });


### PR DESCRIPTION
This PR introduces the ability to computed properties rely on model's events besides the change event. To do this you need define the dependent events with prefix "event:" like this:

``` js
syncCount: Backbone.Computed('event:sync', function() {
  return this.get('syncCount') + 1;
})
```

This can be very useful to create computed properties that rely on the native model events like `sync`, `invalid` or other custom business logic model events.
