### PR TITLE
Considering the full prototype when setup computed properties

### DIFF
--- a/src/backbone-computed.js
+++ b/src/backbone-computed.js
@@ -70,7 +70,7 @@
 
 	function initializeComputedProperties() {
 		var prototypeMember;
-		var prototype = Object.getPrototypeOf(this);
+		var prototype = _.extend({}, Object.getPrototypeOf(this), this.constructor.__super__);
 
 		for (var key in prototype) {
 			if (prototype.hasOwnProperty(key)) {

--- a/tests/backbone-computed.spec.js
+++ b/tests/backbone-computed.spec.js
@@ -54,6 +54,19 @@ describe('Backbone.Computed', function() {
     expect(david.get('username')).to.equal('daviddoe');
   });
 
+  it('should works on extend models', function() {
+    ExtendPerson = Person.extend();
+
+    david = new ExtendPerson({
+      first: 'David',
+      last: 'Tang'
+    });
+
+    expect(david.get('fullName')).to.equal('David Tang');
+    david.set({ last: 'Doe' });
+    expect(david.get('fullName')).to.equal('David Doe');
+  });
+
   it('should not set up any listeners if there are no dependent properties', function() {
     var spy = sinon.spy(Backbone.Model.prototype, 'on');
 


### PR DESCRIPTION
When you extend a model with computed property, the extended model doesn't inherits the parent's computed properties of its parent.

This PR fix this.