### PR TITLE
Loaders friendly "header"

### DIFF
--- a/src/backbone-computed.js
+++ b/src/backbone-computed.js
@@ -1,9 +1,12 @@
-(function() {
-	if (typeof exports !== 'undefined') {
-		_ = require('underscore');
-		Backbone = require('backbone');
-	}
-
+(function(root, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(["backbone", "underscore"], factory);
+  } else if (typeof exports !== "undefined") {
+    return module.exports = factory(require("backbone"), require("underscore"));
+  } else {
+    factory(root.Backbone, root._);
+  }
+})(this, function(Backbone, _) {
 	Backbone.Computed = function(args) {
 		if (this instanceof Backbone.Computed) {
 			args = Array.prototype.slice.call(args, 0);
@@ -86,9 +89,6 @@
 			}
 		}
 	}
-
-	if (typeof exports !== 'undefined') {
-		module.exports = Backbone.Computed;
-	}
-
-})();
+	
+	return Backbone.Computed;
+});


### PR DESCRIPTION
These modifications basically organize the "loaders header" and add support to AMD environments (like require.js).

p.s.: this was based on Backbone's "header" http://backbonejs.org/docs/backbone.html#section-3